### PR TITLE
Align functionality with core Battlesnake engine

### DIFF
--- a/lib/snek.engine.js
+++ b/lib/snek.engine.js
@@ -53,17 +53,18 @@ const Engine = {
 			const newHead = utils.getMoves(snek.head)[moves[idx]];
 			const location = utils.inspect(state, newHead);
 
+			snek.head = newHead;
+			snek.body.unshift(newHead);
+			snek.body.pop();
+
 			if(location == 'food'){
 				nState.board.food = state.board.food.filter(({x,y})=>x!=newHead.x&&y!=newHead.y);
 				snek.health = MAX_HEALTH;
 				snek.length += 1;
+				snek.body.push(snek.body[snek.body.length-1]);
 			}
 			if(location == 'wall') return false;
 			if(snek.health <= 0) return false;
-
-			snek.body = [newHead].concat(snek.body);
-			snek.head = newHead;
-			snek.body = snek.body.slice(0, snek.length);
 
 			return snek;
 		})
@@ -106,6 +107,7 @@ const Engine = {
 		const recur = async ()=>{
 			const prevState = state;
 			const moves = await Promise.all(state.board.snakes.map((snek)=>{
+				if (!snakes[snek.name]) return Promise.resolve('up');
 				return snakes[snek.name].move(Object.assign(
 					clone(state),
 					{ you : snek }

--- a/lib/snek.engine.js
+++ b/lib/snek.engine.js
@@ -58,7 +58,7 @@ const Engine = {
 			snek.body.pop();
 
 			if(location == 'food'){
-				nState.board.food = state.board.food.filter(({x,y})=>x!=newHead.x&&y!=newHead.y);
+				nState.board.food = state.board.food.filter(({x,y})=>x!=newHead.x||y!=newHead.y);
 				snek.health = MAX_HEALTH;
 				snek.length += 1;
 				snek.body.push(snek.body[snek.body.length-1]);

--- a/lib/snek.engine.js
+++ b/lib/snek.engine.js
@@ -5,6 +5,8 @@ const sample = (arr, count=1, r=new Set())=>{
 	return (r.size == count) ? Array.from(r) : sample(arr, count, r);
 };
 
+const clone = (object)=>JSON.parse(JSON.stringify(object));
+
 const MAX_HEALTH = 100;
 
 const Engine = {
@@ -93,21 +95,23 @@ const Engine = {
 		let history = [];
 		if(!state) state = Engine.create(Object.keys(snakes));
 
-		Object.values(snakes).map(({start})=>start && start());
+		Object.entries(snakes).map(([key, snake])=>{
+			if(!snake.start) return;
+			const you = state.board.snakes.find(({ name })=>key===name);
+			snake.start(Object.assign(clone(state), { you }));
+		});
 		history.push(state);
 		cb(state);
 
 		const recur = async ()=>{
 			const prevState = state;
 			const moves = await Promise.all(state.board.snakes.map((snek)=>{
-				return snakes[snek.name].move({
-					...state,
-					you : snek
-				});
+				return snakes[snek.name].move(Object.assign(
+					clone(state),
+					{ you : snek }
+				));
 			}));
 			state = Engine.next(state, moves);
-
-			//TODO: implement 'end'
 
 			history.push(state);
 			cb(state);
@@ -116,7 +120,9 @@ const Engine = {
 				? await recur()
 				: history
 		};
-		return recur();
+		await recur();
+		Object.values(snakes).map(({end})=>end && end(clone(state)));
+		return history;
 	},
 }
 module.exports = Engine;


### PR DESCRIPTION
This is basically three things:
- supply state object to `start` and `end` functions (and deep-clone it so the snake can't affect global state)
- make the snake body length grow _after_ eating food, like in the core engine
- fix a bug where eating a food disc would also delete any other food discs along the same x _or_ y coordinate